### PR TITLE
add calback tesults.results function

### DIFF
--- a/cypress-tesults-reporter.js
+++ b/cypress-tesults-reporter.js
@@ -24,7 +24,7 @@ const caseFiles = (filesDir, suite, name) => {
     return files;
 }
 
-module.exports.results = function (results, args) {
+module.exports.results = function (results, args, callback) {
     if (results === undefined || args === undefined) {
         return;
     }
@@ -200,6 +200,9 @@ module.exports.results = function (results, args) {
                 console.log('Message: ' + response.message);
                 console.log('Warnings: ' + response.warnings.length);
                 console.log('Errors: ' + response.errors.length);
+            }
+            if (typeof callback == 'function') {
+                callback(response, err)
             }
         });
     } catch (err) {


### PR DESCRIPTION
Hi, my team needs a callback in the tesults.result function so that we know when the upload is finished and so we can add treatments in our continuous integration (GitlabCI)
Without the callback, my test pipeline was returning success even when some test failed and with the callback I can solve this problem. Thankss 😃 